### PR TITLE
Add serviceAccountRegex as top level property for Job

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/brigadier",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Brigade library for pipelines and events",
   "main": "out/index.js",
   "types": "out/index.d.ts",

--- a/src/job.ts
+++ b/src/job.ts
@@ -207,6 +207,9 @@ export abstract class Job {
    */
   public serviceAccount?: string;
 
+  /** The regex to validate project service account */
+  public serviceAccountRegex?: string;
+
   /** Set the resource requests for the containers */
   public resourceRequests: JobResourceRequest;
 

--- a/test/job.ts
+++ b/test/job.ts
@@ -120,6 +120,13 @@ describe("job", function() {
           assert.equal(j.serviceAccount, "svcAccount");
         });
       });
+      context("when serviceAccountRegex is supplied", function() {
+        it("sets serviceAccountRegex property", function() {
+          j = new mock.MockJob("my-name", "alpine:3.4", [], true);
+          j.serviceAccountRegex = "svcAccountRegex";
+          assert.equal(j.serviceAccountRegex, "svcAccountRegex");
+        });
+      });
     });
     describe("#podName", function() {
       beforeEach(function() {


### PR DESCRIPTION
https://github.com/Azure/brigade/pull/752 added a service account regex, but actually testing for its correctness was almost impossible (see https://github.com/Azure/brigade/issues/808).

This updates the Job definition to include it.

cc @vdice 