### PR TITLE
Remove job service account regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/brigadier",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Brigade library for pipelines and events",
   "main": "out/index.js",
   "types": "out/index.d.ts",

--- a/src/job.ts
+++ b/src/job.ts
@@ -207,9 +207,6 @@ export abstract class Job {
    */
   public serviceAccount?: string;
 
-  /** The regex to validate project service account */
-  public serviceAccountRegex?: string;
-
   /** Set the resource requests for the containers */
   public resourceRequests: JobResourceRequest;
 

--- a/test/job.ts
+++ b/test/job.ts
@@ -120,13 +120,6 @@ describe("job", function() {
           assert.equal(j.serviceAccount, "svcAccount");
         });
       });
-      context("when serviceAccountRegex is supplied", function() {
-        it("sets serviceAccountRegex property", function() {
-          j = new mock.MockJob("my-name", "alpine:3.4", [], true);
-          j.serviceAccountRegex = "svcAccountRegex";
-          assert.equal(j.serviceAccountRegex, "svcAccountRegex");
-        });
-      });
     });
     describe("#podName", function() {
       beforeEach(function() {


### PR DESCRIPTION
After going back and forth for a while, we shouldn't actually expose the job service account regex to the Job object -- even if it was a read-only property.