### PR TITLE
chore(*): updates per brigadecore org transfer

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,6 +1,6 @@
 # Contributing to Brigadier
 
-Brigadier is part of the [Brigade Core](https://github.com/Azure/brigade). Make sure you test your changes with Brigade.
+Brigadier is part of the [Brigade Core](https://github.com/brigadecore/brigade). Make sure you test your changes with Brigade.
 
 ## Publishing Brigadier
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Because there is no `JobRunner` implementation, executing `job.run()` is a no-op
 
 ## Installation
 
-[![NPM](https://nodei.co/npm/@azure/brigadier.png)](https://www.npmjs.com/package/@azure/brigadier)
+[![NPM](https://nodei.co/npm/@brigadecore/brigadier.png)](https://www.npmjs.com/package/@brigadecore/brigadier)
 
 Install with Yarn, NPM, etc.:
 
 ```console
-$ yarn add @azure/brigadier
+$ yarn add @brigadecore/brigadier
 ```
 
 While this library is fairly stable, it is considered best to match the version of this library
@@ -32,10 +32,10 @@ to the version of Brigade that you are using.
 
 ## Usage
 
-The API is the same here as in [Brigade's API](https://github.com/Azure/brigade/blob/master/docs/topics/javascript.md):
+The API is the same here as in [Brigade's API](https://github.com/brigadecore/brigade/blob/master/docs/topics/javascript.md):
 
 ```javascript
-const {events, Job} = require("@azure/brigadier");
+const {events, Job} = require("@brigadecore/brigadier");
 
 events.on("push", (e, p) => {
     console.log("Got a push event");
@@ -46,4 +46,4 @@ events.on("push", (e, p) => {
 });
 ```
 
-To learn more, visit the [official scripting guide](https://github.com/Azure/brigade/blob/master/docs/topics/scripting.md).
+To learn more, visit the [official scripting guide](https://github.com/brigadecore/brigade/blob/master/docs/topics/scripting.md).

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "@azure/brigadier",
+  "name": "@brigadecore/brigadier",
   "version": "0.4.0",
   "description": "Brigade library for pipelines and events",
   "main": "out/index.js",
   "types": "out/index.d.ts",
-  "author": "Azure Cloud Native Team",
+  "author": "Brigade Core Maintainers",
   "license": "MIT",
-  "homepage": "https://github.com/Azure/brigadier",
+  "homepage": "https://github.com/brigadecore/brigadier",
   "bugs": {
-    "url": "https://github.com/Azure/brigadier/issues"
+    "url": "https://github.com/brigadecore/brigadier/issues"
   },
   "scripts": {
     "compile": "tsc -p ./",

--- a/src/job.ts
+++ b/src/job.ts
@@ -203,7 +203,7 @@ export abstract class Job {
    * Different Brigade worker implementations may choose to honor or ignore this
    * for security or configurability reasons.
    *
-   * See https://github.com/Azure/brigade/issues/251
+   * See https://github.com/brigadecore/brigade/issues/251
    */
   public serviceAccount?: string;
 


### PR DESCRIPTION
Naive string updates in anticipation of the org move to `brigadecore`.

I'm sure this doesn't include the work to update npm publishing.  Ping @technosophos or @radu-matei to help on this detail.

Please comment on/identify other changes that may also be needed.

Related: 
https://github.com/Azure/brigade/pull/847
https://github.com/Azure/brigade-charts/pull/36
https://github.com/Azure/brigade-github-app/pull/38
