### PR TITLE
fix(package.json): add types/request dep to fix ts compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^0.7.2",
+    "@types/request": "^2.48.1",
     "child-process-promise": "^2.2.1",
     "pretty-error": "^2.1.1",
     "ulid": "^0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,11 @@
     underscore "^1.9.1"
     ws "^6.1.0"
 
+"@types/caseless@*":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
+  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
+
 "@types/chai@^4.0.1":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.4.tgz#5ca073b330d90b4066d6ce18f60d57f2084ce8ca"
@@ -26,6 +31,13 @@
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+
+"@types/form-data@*":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.2.1.tgz#ee2b3b8eaa11c0938289953606b745b738c54b1e"
+  integrity sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/fs-extra@5.0.1":
   version "5.0.1"
@@ -69,12 +81,27 @@
   version "10.5.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.7.tgz#960d9feb3ade2233bcc9843c918d740b4f78a7cf"
 
+"@types/request@^2.48.1":
+  version "2.48.1"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.1.tgz#e402d691aa6670fbbff1957b15f1270230ab42fa"
+  integrity sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/form-data" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+
 "@types/shelljs@0.7.8":
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.8.tgz#4b4d6ee7926e58d7bca448a50ba442fd9f6715bd"
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
+
+"@types/tough-cookie@*":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.5.tgz#9da44ed75571999b65c37b60c9b2b88db54c585d"
+  integrity sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==
 
 JSONSelect@0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Typescript compilation appeared to be failing for this project:
```
 $ npm run compile

> @brigadecore/brigadier@0.4.0 compile /Users/vdice/go/src/github.com/brigadecore/brigadier
> tsc -p ./

node_modules/@kubernetes/client-node/dist/api.d.ts:13:26 - error TS7016: Could not find a declaration file for module 'request'. '/Users/vdice/go/src/github.com/brigadecore/brigadier/node_modules/request/index.js' implicitly has an 'any' type.
  Try `npm install @types/request` if it exists or add a new declaration (.d.ts) file containing `declare module 'request';`

13 import request = require('request');
                            ~~~~~~~~~

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! @brigadecore/brigadier@0.4.0 compile: `tsc -p ./`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the @brigadecore/brigadier@0.4.0 compile script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/vdice/.npm/_logs/2019-06-10T23_11_56_912Z-debug.log
```

Adding the corresponding `@types/request` library appears to fix it.  (I referenced [brigade-utils](https://github.com/brigadecore/brigade-utils/blob/master/package.json#L30) for version)