### PR TITLE
fix type of callback for EventRegistry.on

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -279,7 +279,7 @@ export class EventRegistry extends EventEmitter {
    * @param eventName The name of the event
    * @param cb A callback of the format described in type EventHandler
    */
-  public on(eventName: string | symbol, cb: ((...args: any[]) => void)): this {
+  public on(eventName: string | symbol, cb: EventHandler): this {
     return super.on(eventName, cb);
   }
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -253,7 +253,7 @@ export class EventRegistry extends EventEmitter {
    */
   constructor() {
     super();
-    this.on("ping", (e: BrigadeEvent, p: Project) => {
+    this.on("ping", (e: BrigadeEvent, p?: Project) => {
       console.log("ping");
     });
   }

--- a/test/events.ts
+++ b/test/events.ts
@@ -28,7 +28,7 @@ describe("events", function() {
     });
     describe("#on", function() {
       it("registers an event handler", function() {
-        er.on("my-event", (e: events.BrigadeEvent, p: events.Project) => {});
+        er.on("my-event", (e: events.BrigadeEvent, p?: events.Project) => {});
         assert.isTrue(er.has("my-event"));
       });
     });
@@ -39,7 +39,7 @@ describe("events", function() {
         let myEvent = mock.mockEvent();
         let myProj = mock.mockProject();
         myEvent.type = ename;
-        er.on(ename, (e: events.BrigadeEvent, p: events.Project) => {
+        er.on(ename, (e: events.BrigadeEvent, p?: events.Project) => {
           fired = true;
         });
         er.fire(myEvent, myProj);


### PR DESCRIPTION
While the jsdoc mentions that the callback should be of type `EventHandler`, the code doesn't.