### PR TITLE
fix(brigade.js): just run build directly for exec

### DIFF
--- a/brigade.js
+++ b/brigade.js
@@ -56,7 +56,9 @@ events.on("push", (e, p) => {
     }
 });
 
-events.on("exec", runSuite);
+events.on("exec", (e, p) => {
+  return build().run();
+});
 events.on("check_suite:requested", runSuite);
 events.on("check_suite:rerequested", runSuite);
 events.on("issue_comment:created", (e, p) => Check.handleIssueComment(e, p, runSuite));


### PR DESCRIPTION
Updates the `brigade.js` script to have the default `exec` event just run the build directly, outside of the context of a GH Check run, as most likely this event would be called standalone/during dev, etc.