### PR TITLE
Adding support for ssh certificates

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -138,7 +138,11 @@ export interface Repository {
    * sshKey the SSH key to use for ssh:// or git+ssh:// protocols
    */
   sshKey?: string;
-
+  /**
+   * sshCert the SSH certificate to use for ssh:// or git+ssh:// protocols
+   *  more details could be found at https://github.blog/2019-08-14-ssh-certificate-authentication-for-github-enterprise-cloud/
+   */
+  sshCert?: string;
   /**
    * token is the OAuth2 token for Git interactions over HTTPS
    */


### PR DESCRIPTION
Oneliner to add sshCert string field.
Please see  https://github.com/brigadecore/brigade/pull/1008 for more details.
Signed-off-by: Valery Masiutsin <val.masutin@gmail.com>